### PR TITLE
Make no-unused-prop-types an error

### DIFF
--- a/packages/eslint-config-quri/rules/react.js
+++ b/packages/eslint-config-quri/rules/react.js
@@ -287,7 +287,7 @@ module.exports = {
 
     // Prevent unused propType definitions
     // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-unused-prop-types.md
-    'react/no-unused-prop-types': ['warn', {
+    'react/no-unused-prop-types': ['error', {
       customValidators: [
       ],
       skipShapeProps: true,


### PR DESCRIPTION
As this can easily lead to bugs, what do you guys think?